### PR TITLE
Pass TARGETARCH from acceptance tests

### DIFF
--- a/acceptance/container.go
+++ b/acceptance/container.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -232,9 +233,13 @@ func getContainerLogs(ctx context.Context, contID string) string {
 }
 
 func buildContainerImage(ctx context.Context) error {
+	targetArch := runtime.GOARCH
 	opts := types.ImageBuildOptions{
 		Dockerfile: "Containerfile",
 		Tags:       []string{containerImage},
+		BuildArgs: map[string]*string{
+			"TARGETARCH": &targetArch,
+		},
 	}
 
 	buildContextPath, err := filepath.Abs("..")


### PR DESCRIPTION
The Containerfile uses the TARGETARCH to download the appropriate version of oras. This var is not passed in when building from the acceptance tests, so need to pass it in.

https://issues.redhat.com/browse/EC-656