### PR TITLE
Format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -450,8 +450,12 @@ spec:
       params:
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       runAfter:
-        - clone-repository
+        - build-container
       taskRef:
         params:
           - name: name


### PR DESCRIPTION
This update configures the SAST task to upload SARIF results to quay.io for long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263