### PR TITLE
allow the use of empty DEBUG env var

### DIFF
--- a/create-oci.sh
+++ b/create-oci.sh
@@ -22,7 +22,7 @@ set -o pipefail
 # using `-n` ensures gzip does not add a modification time to the output. This
 # helps in ensuring the archive digest is the same for the same content.
 tar_opts=(--create --use-compress-program='gzip -n' --file)
-if [[ -v DEBUG ]]; then
+if [[ ! -z "${DEBUG:-}" ]]; then
   tar_opts=(--verbose "${tar_opts[@]}")
   set -o xtrace
 fi

--- a/create.sh
+++ b/create.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 tar_opts=-czf
-if [[ -v DEBUG ]]; then
+if [[ ! -z "${DEBUG:-}" ]]; then
   tar_opts=-cvzf
   set -o xtrace
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ log() {
     :
 }
 
-if [[ -v DEBUG ]]; then
+if [[ ! -z "${DEBUG:-}" ]]; then
     time_format='User:\t\t%U\nSystem:\t\t%S\nElapsed:\t%E\nCPU:\t\t%P\nMax RS:\t\t%MKiB\nAVG Memory:\t%KKiB\nInputs:\t\t%I\nOutputs:\t%O\nWaits:\t\t%w\n'
     log() {
         # shellcheck disable=SC2059

--- a/oras_opts.sh
+++ b/oras_opts.sh
@@ -6,6 +6,6 @@ if [[ -v CA_FILE ]]; then
     oras_opts+=(--ca-file=${CA_FILE})
 fi
 
-if [[ -v DEBUG ]]; then
+if [[ ! -z "${DEBUG:-}" ]]; then
     oras_opts+=(--debug)
 fi

--- a/use-oci.sh
+++ b/use-oci.sh
@@ -14,7 +14,7 @@ set -o nounset
 set -o pipefail
 
 tar_opts=-zxpf
-if [[ -v DEBUG ]]; then
+if [[ ! -z "${DEBUG:-}" ]]; then
   tar_opts=-zxvpf
   set -o xtrace
 fi

--- a/use.sh
+++ b/use.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 tar_opts=-xpf
-if [[ -v DEBUG ]]; then
+if [[ ! -z "${DEBUG:-}" ]]; then
   tar_opts=-xvpf
   set -o xtrace
 fi


### PR DESCRIPTION
In the case where you are configuring a pipeline with many tasks, it can be handy to be able to turn on DEBUG for all tasks by setting a single param value.

```
    - name: trustedArtifactsDebug
      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
      type: string
      default: ""
```

Task debugging can then be configured with this:

```
  stepTemplate:
    env:
      - name: DEBUG
        value: $(params.trustedArtifactsDebug)
```

Without this change, the mere setting of an empty DEBUG env var, would turn on logging.