### PR TITLE
Add retries around oras operations

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,6 +4,7 @@ COPY centos9-stream.repo /etc/yum.repos.d/centos9-stream.repo
 COPY RPM-GPG-KEY-centosofficial /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 COPY create-oci.sh /usr/local/bin/create-archive
 COPY select-oci-auth.sh /usr/local/bin/select-oci-auth.sh
+COPY retry.sh /usr/local/bin/retry.sh
 COPY use-oci.sh /usr/local/bin/use-archive
 COPY oras_opts.sh /usr/local/bin/oras_opts.sh
 COPY entrypoint.sh /usr/local/bin/entrypoint

--- a/create-oci.sh
+++ b/create-oci.sh
@@ -103,7 +103,7 @@ if [ ${#artifacts[@]} != 0 ]; then
     fi
 
     pushd "${archive_dir}" > /dev/null
-    oras push "${oras_opts[@]}" --registry-config <(select-oci-auth.sh ${repo}) "${store}" "${artifacts[@]}"
+    retry.sh oras push "${oras_opts[@]}" --registry-config <(select-oci-auth.sh ${repo}) "${store}" "${artifacts[@]}"
     popd > /dev/null
 
     echo 'Artifacts created'

--- a/retry.sh
+++ b/retry.sh
@@ -2,6 +2,11 @@
 # Retry a command a few times if it fails
 # https://github.com/konflux-ci/build-trusted-artifacts/tree/main/retry.sh
 
+# Note: There is a similar retry script in
+# https://github.com/konflux-ci/oras-container/blob/main/hack/retry.sh
+# Potentially we could be using that shared base image here, and
+# consolidating the way the oras retries are done
+
 retry() {
   status=-1
   max_try=12

--- a/retry.sh
+++ b/retry.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Retry a command a few times if it fails
+# https://github.com/konflux-ci/build-trusted-artifacts/tree/main/retry.sh
+
+retry() {
+  status=-1
+  max_try=12
+  wait_sec=2
+
+  for run in $(seq 1 $max_try); do
+    status=0
+    echo "Executing (attempt $run):  $" "${@}" >&2
+    "$@"
+    status=$?
+    if [ "$status" -eq 0 ]; then
+      break
+    fi
+    sleep $wait_sec
+  done
+  if [ "$status" -ne 0 ]; then
+    echo "Failed after ${max_try} tries with status ${status}" >&2
+    exit "$status"
+  fi
+}
+
+retry "$@"

--- a/use-oci.sh
+++ b/use-oci.sh
@@ -73,7 +73,7 @@ for artifact_pair in "${artifact_pairs[@]}"; do
 
     name="${uri#*:}"
 
-    oras blob fetch "${oras_opts[@]}" --registry-config <(select-oci-auth.sh ${name}) \
+    retry.sh oras blob fetch "${oras_opts[@]}" --registry-config <(select-oci-auth.sh ${name}) \
         "${name}" --output - | tar -C "${destination}" "${tar_opts}" -
 
     echo "Restored artifact ${name} to ${destination}"


### PR DESCRIPTION
Includes work from @ralphbean (originally in PR #158) rebased on the latest main to fix the [CI failures](https://github.com/konflux-ci/build-trusted-artifacts/pull/158/checks?check_run_id=39982623161).